### PR TITLE
fixed URL cache for play.google.com/music

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -22,7 +22,7 @@ var URL_cache = function()
     "google": null,
     "slacker": null,
     "thesixtyone": null,
-    "music.google": null
+    "play.google": null
   };
 };
 


### PR DESCRIPTION
The URL cache listed music.google, but it needs to be play.google
