### PR TITLE
Readme tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,54 @@
 
 Chrome extension to send "global" (ie. across the browser) hotkeys to various online media players.
 
-##Installation
+It is available on the Chrome Store at the following location:
 
-####Requirements
-Node.js
+https://chrome.google.com/webstore/detail/streamkeys/ekpipjofdicppbepocohdlgenahaneen?hl=en
 
-####Install
+## Installation
+
+#### Requirements
+
+- Node.js
+
+#### Install
+
 Clone the repo and then
+
 ```bash
 $ npm install
 ```
-to install dependencies. To build the extension run
+
+to install dependencies. Then to build the extension run
+
 ```bash
 $ grunt dev
 ```
 
-##Grunt Tasks
-`grunt dev`: Lints `code/*`, runs browserify and copies built code to `build/unpacked-dev/` and `test/streamkeys-ext/`
+## Grunt Tasks
 
-`grunt rel`: Lints `code/*`, runs browserify and uglify and copies built code to `build/unpacked-prod/` and `test/streamkeys-ext/`
+- `grunt dev`: Lints `code/*`, runs browserify and copies built code to `build/unpacked-dev/` and `test/streamkeys-ext/`
 
-`grunt watch`: Watches for changes to JS files in `code/*`, lints `code/*`, runs browserify and copies built code to `build/unpacked-dev/`
+- `grunt rel`: Lints `code/*`, runs browserify and uglify and copies built code to `build/unpacked-prod/` and `test/streamkeys-ext/`
 
-`grunt lint`: Lints `code/*`
+- `grunt watch`: Watches for changes to JS files in `code/*`, lints `code/*`, runs browserify and copies built code to `build/unpacked-dev/`
 
-`grunt rel-test`: Everything in `rel` and then runs the test suite
+- `grunt lint`: Lints `code/*`
 
-##Info:
-This extension works by sending click events to the elements that control the music player. Each music site has an associated controller which contains the css selectors for the play/pause/next/previous/mute buttons (where available). In addition there is a `BaseController` module which contains common functions that are shared across all controllers.
+- `grunt rel-test`: Everything in `rel` and then runs the test suite
+
+## Info
+
+This extension works by sending click events to the elements that control the music player. Each music site has an associated controller which contains the css selectors for the play/pause/next/previous/mute buttons (where available). In addition there is a [`BaseController`][0] module which contains common functions that are shared across all controllers.
 
 The background script routes hotkey presses from the user to the correct tab (ie., the media player(s) tab) if the media player site is enabled.
 
-##Adding Sites:
-Adding a new site to the extension is pretty easy. There are 3 steps:
+## Adding Sites
 
-####Add site controller
+Adding a new site to the extension is straight forward. There are 3 steps:
+
+#### 1. Add site controller
+
 Figure out the css selectors for a site's media player buttons and create a new controller in `code/js/controllers/`. Naming scheme is `{Sitename}Controller.js`. You should copy code from an exisiting controller as a template. Here is an example controller for Fooplayer:
 
 ```javascript
@@ -54,15 +67,17 @@ Filename: FooplayerController.js
 })();
 ```
 
-####Add site to sitelist
-Next add the site to the Sitelist object in `code/js/modules/Sitelist.js`. It is important that the url is correct, and that the object's name is contained in the URL.
+#### 2. Add site to sitelist
+
+Next, add the site to the Sitelist object in `code/js/modules/Sitelist.js`. It is important that the url is correct, and that the object's name is contained in the URL.
 
 ```javascript
 "fooplay": {name: "Fooplay", url: "http://www.fooplayer.com", enabled: true, url_regex: null}
 ```
 
-####Add controller to manifest
-Finally, add your new controller to the `content_scripts` array in the manifest file.
+#### 3. Add controller to manifest
+
+Finally, add your new controller to the `content_scripts` array in the manifest file. Ensuring to correctly set the matching site.
 
 ```javascript
 {
@@ -71,24 +86,31 @@ Finally, add your new controller to the `content_scripts` array in the manifest 
 }
 ```
 
-##Tests:
-There is a Mocha/Selenium integration test suite that is intended to discover if a site changes their players which will break the extension. The automated Travis-CI with trigger on every pull request/push. To run the tests locally you will require chromedriver somehwere in your path. The node module `selenium-chromedriver` will do that for you. After `npm install` the chromedriver binary can be found in `node_modules/selenium-chromedriver/bin`. To run the tests:
+## Tests
+
+There is a Mocha/Selenium integration test suite that is intended to discover if a site changes their players which will break the extension. The automated Travis-CI will trigger on every pull request/push.
+
+To run the tests locally you will require ChromeDriver somewhere in your path. The node module `selenium-chromedriver` will do that for you. After `npm install` the ChromeDriver binary can be found in `node_modules/selenium-chromedriver/bin`. To run the tests:
+
 ```
 node test/runner.js
 ```
 
-##Default hotkeys:
+## Default hotkeys
 
-* Mediakeys: play/pause, next, previous
-* Ctrl + Shift + 2: mute
+- Mediakeys: play/pause, next, previous
+- `Ctrl` + `Shift` + `2`: mute
 
-##TODO:
-* Redo tab stack
-* See if media keys can work with mac
-* Test on Ubuntu/Linux and ChromeOS
-* See if it can work with embedded players (ie. soundcloud). Maybe check for existence of some element, if found add tab to stack (should be done after load)?
-* Add tests for Amazon, Pandora, Plex, PocketCasts Seesu, Spotify, VK
+## TODO
 
-##License (MIT)
+- Redo tab stack
+- See if media keys can work with mac
+- Test on Ubuntu/Linux and ChromeOS
+- See if it can work with embedded players (ie. soundcloud). Maybe check for existence of some element, if found add tab to stack (should be done after load)?
+- Add tests for Amazon, Pandora, Plex, PocketCasts Seesu, Spotify, VK
+
+## License (MIT)
 
 Copyright (c) 2014 Alex Gabriel under the MIT license.
+
+[0]: https://github.com/berrberr/streamkeys/blob/master/code/js/modules/BaseController.js


### PR DESCRIPTION
Just a little tidy up of the readme.
- Included link to chromestore release
- Typo fixtures
- Tidy up

I was going to include stuff like how to get the chrome driver onto the path. For example on windows it'll be 

`set PATH=%PATH%;node_modules\selenium-chromedriver\bin` but I think that's too platform specific.
