### PR TITLE
Add Emby

### DIFF
--- a/code/js/controllers/EmbyController.js
+++ b/code/js/controllers/EmbyController.js
@@ -1,0 +1,16 @@
+;(function() {
+  "use strict";
+
+  var controller = require("BaseController");
+
+  controller.init({
+    siteName: "Emby",
+    play: ".unpauseButton",
+    pause: ".pauseButton",
+    playNext: ".nextTrackButton",
+    playPrev: ".previousTrackButton",
+
+    pauseState: ".pauseButton.hide",
+    playState: ".unpauseButton.hide"
+  });
+})();

--- a/code/js/modules/Sitelist.js
+++ b/code/js/modules/Sitelist.js
@@ -34,6 +34,7 @@
       "disco": {name: "Disco.io", url: "http://www.disco.io", enabled: true},
       "earbits": {name: "Earbits", url: "http://www.earbits.com", enabled: true},
       "player.edge": {name: "Edge Player", url: "http://player.edge.ca", controller: "EdgeController.js", enabled: true},
+      "emby": {name: "Emby", url: "http://app.emby.media", enabled: true},
       "gaana": {name: "Gaana", url: "http://www.gaana.com", enabled: true},
       "play.google": {name: "Google Play Music", url: "http://play.google.com", controller: "GoogleMusicController.js", enabled: true},
       "grooveshark": {name: "Grooveshark", url: "http://www.grooveshark.com", enabled: true},


### PR DESCRIPTION
Adds support for [Emby web player](http://emby.media/). Much like Plex.tv, this will only work as documented in #41.