### PR TITLE
Use Media Stop key as default to Stop all players

### DIFF
--- a/code/manifest.json
+++ b/code/manifest.json
@@ -59,6 +59,9 @@
       "description": "Toggle mute"
     },
     "stop": {
+      "suggested_key": {
+        "default": "MediaStop"
+      },
       "global": true,
       "description": "Stop all players"
     },


### PR DESCRIPTION
By default it's just unset, but you may as well offer this as a default :)