### PR TITLE
Hide play controls in the popup when a tab fails canPlayPause

### DIFF
--- a/code/js/popup.js
+++ b/code/js/popup.js
@@ -157,6 +157,14 @@ var Popup = function() {
       $siteContainer.find("#playPrev").addClass("disabled");
     }
 
+    // Hide the site container if there are no usable buttons
+    if(!stateData.canPlayPause) {
+      $siteContainer.hide();
+    }
+    else {
+      $siteContainer.show();
+    }
+
     // Set the button state for playNext
     if(stateData.canPlayNext) {
       $siteContainer.find("#playNext").removeClass("disabled");


### PR DESCRIPTION
This is a follow up PR to https://github.com/berrberr/streamkeys/pull/116 . As requested these are the `hasPlayer` changes. We discussed in https://github.com/berrberr/streamkeys/pull/116 that this change will sometimes leave the popup with no play controls and does not display `.js-no-sites`, for example if your only open tab is an amazon shopping page with no amazon music player. I attempted to fix this by changing things in `getTabStates` but I never got successful results. If you merge this PR the `.js-no-sites` issue will need to be fixed before release.