### PR TITLE
Quick fix for Deezer's like and dislike actions

### DIFF
--- a/code/js/controllers/DeezerController.js
+++ b/code/js/controllers/DeezerController.js
@@ -13,8 +13,8 @@
     playNext: ".control.control-next",
     playPrev: ".control.control-prev",
     mute: ".icon-volume-off",
-    like: ".icon-love",
-    dislike: ".icon-unlove",
+    like: ".player-actions .icon-love",
+    dislike: ".player-actions .icon-unlove",
     buttonSwitch: isNew,
 
     song: ".player-track-title > span",


### PR DESCRIPTION
There are meany elements on current deezer page with 'icon-love' class. First is the one in menu item 'Favourite tracks', and this one was triggered for 'like' action.
I've changed like/dislike selectors to be more specific and match only icons in player component.