### PR TITLE
BBC radio player fixup

### DIFF
--- a/code/js/controllers/BBCRadioController.js
+++ b/code/js/controllers/BBCRadioController.js
@@ -7,7 +7,8 @@
     play: "#play",
     pause: "#pause",
     mute: "#volume-mute",
-    like: "#toggle-mystations > span",
+    like: "#toggle-mystations:not(.in-mystations) > span",
+    dislike: "#toggle-mystations.in-mystations > span",
 
     song: "p.title > a",
     artist: "p.artist > a",

--- a/code/js/controllers/BBCRadioController.js
+++ b/code/js/controllers/BBCRadioController.js
@@ -6,6 +6,8 @@
     siteName: "BBC Radio",
     play: "#play",
     pause: "#pause",
+    playNext: ".od-skip[data-offset='60']",
+    playPrev: ".od-skip[data-offset='-60']",
     mute: "#volume-mute",
     like: "#toggle-mystations:not(.in-mystations) > span",
     dislike: "#toggle-mystations.in-mystations > span",

--- a/code/js/controllers/BBCRadioController.js
+++ b/code/js/controllers/BBCRadioController.js
@@ -4,8 +4,8 @@
   var controller = require("BaseController");
   controller.init({
     siteName: "BBC Radio",
-    play: "#btn-play",
-    pause: "#btn-pause",
+    play: "#play",
+    pause: "#pause",
     mute: "#volume-mute",
     like: "#toggle-mystations > span",
 


### PR DESCRIPTION
The BBC radio player plugin was broken due to some incorrect selectors, I've added a few more too whilst there. Works with both ["listen again" programme streaming pages](http://www.bbc.co.uk/radio/player/b0675n1t) and ["as-live" radio station pages](http://www.bbc.co.uk/radio/player/bbc_6music). In theory one could support all the radioplayer.co.uk pages, however they all sit on their station URLs, so I'm not sure how you'd manage that.

Thanks for a nice extension! FWIW I use this under Chromium on Debian Unstable, so your "Test on Ubuntu/Linux" TODO item is covered.