### PR TITLE
Hide overflow when track title scrolls in popup.

### DIFF
--- a/code/css/popup.scss
+++ b/code/css/popup.scss
@@ -85,6 +85,7 @@ div a, div a:hover, div a:visited {
 
 .player-row {
   padding: 5px 0 0 0;
+  overflow: hidden;
 }
 
 .site-tab-container {


### PR DESCRIPTION
When the popup is in a window that is larger than the popup and the track title is scrolling, it overflows.

![screen shot 2015-09-24 at 3 30 26 pm](https://cloud.githubusercontent.com/assets/221133/10074604/40f9f2da-62d1-11e5-8ea6-1e76d32666e4.png)
