### PR TITLE
Fixed MouseEventController inheritance from BaseController

### DIFF
--- a/code/js/modules/MouseEventController.js
+++ b/code/js/modules/MouseEventController.js
@@ -6,6 +6,18 @@
       sk_log = require("../modules/SKLog.js");
 
   /**
+   * @class MouseEventController
+   * @extends BaseController
+   * @constructor
+   */
+  function MouseEventController() {
+    BaseController.apply(this, arguments);
+  }
+
+  MouseEventController.prototype = Object.create(BaseController.prototype);
+  MouseEventController.prototype.constructor = MouseEventController;
+
+  /**
    * Dispatch "dblclick" mouse event inside document
    * @param {String} opts.selectorButton - css selector for element
    */
@@ -51,7 +63,7 @@
       return;
     }
     // based on click method
-    BaseController.prototype[eventType] = function(opts, mouseOpts) {
+    MouseEventController.prototype[eventType] = function(opts, mouseOpts) {
       opts = opts || {};
       if (opts.selectorButton === null) {
         sk_log("disabled", opts.action);
@@ -70,5 +82,5 @@
     };
   });
 
-  module.exports = BaseController;
+  module.exports = MouseEventController;
 })();


### PR DESCRIPTION
In the last commit (#228) class `MouseEventController` is not inherited from `BaseController` correctly. `require("BaseController") === require("MouseEventController")` was `true`. But maybe I misunderstood you.

For the rest, everything works correctly. :+1:

I can not add a commit to opened PR, and do not know whether it is possible to do this. But I realized this after creating a commit. Hopefully there will not be problems with merging.

Not sure that I have written is correct and understandable. Sorry for my English.