### PR TITLE
Fix for BrainFM Controller (Bug #273)

### DIFF
--- a/code/js/controllers/BrainFMController.js
+++ b/code/js/controllers/BrainFMController.js
@@ -6,6 +6,7 @@
   new BaseController({
     siteName: "BrainFM",
     play: "#play_button.tc_play",
-    pause: "#play_button.tc_pause"
+    pause: "#play_button.tc_pause",
+    buttonSwitch: true
   });
 })();


### PR DESCRIPTION
The element for play/pause is swapped out when you play/pause so `buttonSwitch` needs to be set. See Bug #273 for reproduction steps.