### PR TITLE
Fix for Plex Web 3.17.2

### DIFF
--- a/code/js/controllers/PlexController.js
+++ b/code/js/controllers/PlexController.js
@@ -1,16 +1,22 @@
 ;(function() {
   "use strict";
 
-  var BaseController = require("BaseController");
+  var MouseEventController = require("MouseEventController");
 
-  new BaseController({
+  var controller = new MouseEventController({
     siteName: "Plex.tv",
-    play: "button.play-btn:not([tabindex='-1'])",
-    pause: "button.pause-btn:not([tabindex='-1'])",
-    playNext: "button.next-btn",
-    playPrev: "button.previous-btn",
-    mute: "button.volume-btn",
+    play: "button[aria-label='Play'] > i",
+    pause: "button[aria-label='Pause'] > i",
+    playNext: "button[aria-label='Next'] > i",
+    playPrev: "button[aria-label='Previous'] > i",
+    mute: "button[aria-label='Mute Volume'] > i",
 
-    song: ".video-title"
+    song: "[class^=' MetadataPosterTitle-title'] [role=link]",
+    buttonSwitch: true
   });
+
+  controller.click = function(opts) {
+    this.mousedown({ selectorButton: opts.selectorButton });
+    this.mouseup({ selectorButton: opts.selectorButton });
+  };
 })();


### PR DESCRIPTION
Plex now listens to all clicks at the document level. Weird stuff. They also don't listen to `click` events now, but `mousedown`/`mouseup` pairs. Not sure if that's good for a11y...

Anyways, this should fix things up again. 

Fixes #344