### PR TITLE
Update Plex Controller to use class-based selectors

### DIFF
--- a/code/js/controllers/PlexController.js
+++ b/code/js/controllers/PlexController.js
@@ -5,13 +5,13 @@
 
   var controller = new MouseEventController({
     siteName: "Plex.tv",
-    play: "button[aria-label='Play'] > i",
-    pause: "button[aria-label='Pause'] > i",
-    playNext: "button[aria-label='Next'] > i",
-    playPrev: "button[aria-label='Previous'] > i",
-    mute: "button[aria-label='Mute Volume'] > i",
+    play: "i[class^=plex-icon-player-play-]",
+    pause: "i[class^=plex-icon-player-pause-]",
+    playNext: "i[class^=plex-icon-player-next-]",
+    playPrev: "i[class^=plex-icon-player-prev-]",
+    mute: "i[class^=plex-icon-player-volume-]",
 
-    song: "[class^=' MetadataPosterTitle-title'] [role=link]",
+    song: "title",
     buttonSwitch: true
   });
 


### PR DESCRIPTION
Update Plex Controller to use class-based selectors (instead of aria-label). Also take playing title from <title>

This pull request is suggested because the previous fix only worked if Plex was set in English. This is because the aria-label (on which the selector was relying) is translated with the interface. See issue https://github.com/berrberr/streamkeys/issues/344#issuecomment-325541148