### PR TITLE
Add StreamSquid

### DIFF
--- a/code/js/controllers/StreamSquidController.js
+++ b/code/js/controllers/StreamSquidController.js
@@ -1,0 +1,53 @@
+;(function() {
+  "use strict";
+
+  var BaseController = require("BaseController");
+
+  var controller = new BaseController({
+    siteName: "streamsquid",
+    play: "#player-play",
+    pause: "#player-pause",
+    playNext: "#player-next",
+    playPrev: "#player-back",
+    like: ".queue-item-selected #queue-item-fav-icon",
+    playState: "#player-pause",
+
+    // These are not selectors, but attribute names that the overridden getSongData uses
+    // Because the attributes contain untruncated song and artist names (unlike the DOM Element text)
+    song: "data-track-name",
+    artist: "data-artist-name",
+  });
+
+  controller.getSelectedQueueItem = function() {
+    return this.doc().querySelector(".queue-item.queue-item-selected");
+  };
+
+  controller.getSongData = function(dataAttribute) {
+    if(!dataAttribute) return null;
+
+    var selectedItem = this.getSelectedQueueItem();
+    if (selectedItem && selectedItem.attributes && selectedItem.attributes[dataAttribute]) {
+      return selectedItem.attributes[dataAttribute].value;
+    }
+
+    return null;
+  };
+
+  controller.getArtData = function() {
+    var selectedItem = this.getSelectedQueueItem();
+
+    if (selectedItem && selectedItem.attributes) {
+      var youtubeIdAttribute = selectedItem.attributes["data-ytid"];
+      var imageUrlAttribute = selectedItem.attributes["data-image-url"];
+      // data-image-url is sometimes set, but equal to the string "undefined"
+      if (imageUrlAttribute && imageUrlAttribute.value && imageUrlAttribute.value !== "undefined") {
+        return imageUrlAttribute.value;
+      }
+      else if (youtubeIdAttribute && youtubeIdAttribute.value) {
+        return "https://img.youtube.com/vi/" + youtubeIdAttribute.value + "/default.jpg";
+      }
+    }
+
+    return null;
+  };
+})();

--- a/code/js/modules/Sitelist.js
+++ b/code/js/modules/Sitelist.js
@@ -159,6 +159,7 @@
       "spotify": { name: "Spotify Web Player", url: "http://www.spotify.com" },
       "spreaker": { name: "Spreaker", url: "http://www.spreaker.com" },
       "stitcher": { name: "Stitcher", url: "http://www.stitcher.com" },
+      "streamsquid": { name: "StreamSquid", url: "http://streamsquid.com/" },
       "subsonic": { name: "Subsonic", url: "http://www.subsonic.org" },
       "tidal": { name: "Tidal", url: "https://www.tidal.com", alias: ["tidalhifi"] },
       "thedrop": { name: "TheDrop", url: "https://www.thedrop.club" },


### PR DESCRIPTION
Adds [StreamSquid](http://streamsquid.com/) as a controller.

One thing I wonder about is if the logic on StreamSquidController.js line 47 should be refactored to share the same default thumbnail URL building logic as YouTubeController.js, but I opted against adding a function they could share to the BaseController prototype, and wasn't sure if adding another module for random utilities would be useful.