### PR TITLE
Player state notify

### DIFF
--- a/code/js/background.js
+++ b/code/js/background.js
@@ -108,7 +108,7 @@
   });
 
   var sendChangeNotification = function(request, sender) {
-    chrome.notifications.create(sender.id, {
+    chrome.notifications.create(sender.id + request.stateData.siteName, {
         type: "list",
         title: request.stateData.siteName,
         message: request.stateData.song || "",

--- a/code/js/modules/BaseController.js
+++ b/code/js/modules/BaseController.js
@@ -250,6 +250,12 @@
       if(request.action === "mute") this.mute();
       if(request.action === "like") this.like();
       if(request.action === "dislike") this.dislike();
+      if(request.action === "playerStateNotify"){
+        chrome.runtime.sendMessage({
+          action: "send_change_notification",
+          stateData: this.getStateData()
+        });
+      }
       if(request.action === "getPlayerState") {
         var newState = this.getStateData();
         this.oldState = newState;

--- a/code/manifest.json
+++ b/code/manifest.json
@@ -76,6 +76,10 @@
     "dislike": {
       "global": true,
       "description": "Toggle dislike"
+    },
+    "playerStateNotify": {
+      "global": true,
+      "description": "Send notification of player(s) state"
     }
   }
 }


### PR DESCRIPTION
This adds 2 things:

1. The ability to have multiple sites send notifications simultaneously; currently there is only one global notification being created for SK.
2. The ability to manually trigger (and bind a hotkey for) a notification of the state of all open players, instead of having to wait until there is a song change event.