### PR TITLE
Fix ShortOrange play/pause (fixes #325) and add art

### DIFF
--- a/code/js/controllers/ShortorangeController.js
+++ b/code/js/controllers/ShortorangeController.js
@@ -5,13 +5,13 @@
 
   new BaseController({
     siteName: "Short Orange",
-    play: ".player-controls .fa-play",
-    pause: ".player-controls .fa-pause",
+    playPause: ".player-controls > .play-button",
     playNext: ".player-controls .fa-forward",
     playPrev: ".player-controls .fa-backward",
 
-    playState: ".fa-pause:not(.ng-hide)",
+    playState: ".player-controls > .play-button > .fa-pause",
     song: ".episode-title",
-    artist: ".podcast-title"
+    artist: ".podcast-title",
+    art: ".now-playing-art"
   });
 })();


### PR DESCRIPTION
Fix for the Play/Pause selectors for ShortOrange, fixes issue #325.  Favored `>` in selectors for (slightly) better performance at the cost of possibly greater fragility should the hierarchy of those elements change.

Also added `art` selector.