### PR TITLE
Add option to interact with most recent tab only.

### DIFF
--- a/code/html/options.html
+++ b/code/html/options.html
@@ -142,6 +142,10 @@
           <input type="checkbox" id="restart-yt" data-bind="checked: $data.youtubeRestart">
           <label for="restart-yt">Play/pause restarts YouTube videos when finished.</label>
         </p>
+        <p class="setting">
+          <input type="checkbox" id="single-player-mode" data-bind="checked: $data.singlePlayerMode">
+          <label for="single-player-mode">Hotkeys interact with most recent player only.</label>
+        </p>
         <p>
           To change the hotkey bindings go to the chrome extensions page (enter chrome://extensions in the URL bar) and click the "Keyboard shortcuts" link at the bottom of the page. <a href="http://www.streamkeys.com/guide.html" target="_blank">Read the guide</a>          for more detailed information
         </p>

--- a/code/js/background.js
+++ b/code/js/background.js
@@ -66,7 +66,7 @@
   };
 
   /**
-   * Returns most tab of most recently updated status.
+   * Returns tab with most recently updated status.
    */
   var getRecentTab = function(tabs) {
     return _.max(tabs, function(tab) {

--- a/code/js/background.js
+++ b/code/js/background.js
@@ -67,7 +67,7 @@
 
   /**
    * Returns "best" tab:
-   * - if any tab is updated after 200ms after any other
+   * - if there is one tab is updated 200ms after all others
    * - otherwise active tab
    * - otherwise most recently updated
    */

--- a/code/js/options.js
+++ b/code/js/options.js
@@ -40,6 +40,11 @@ var OptionsViewModel = function OptionsViewModel() {
       chrome.storage.sync.set({ "hotkey-youtube_restart": value });
     });
 
+    self.singlePlayerMode = ko.observable(obj["hotkey-single_player_mode"]);
+    self.singlePlayerMode.subscribe(function(value) {
+      chrome.storage.sync.set({ "hotkey-single_player_mode": value });
+    });
+
     self.settingsInitialized(true);
   });
 


### PR DESCRIPTION
See issue #337 and #322.

@berrberr Please suggest what tests you would like to see.

I also wonder if this should be under the option. I, personally, don't see the usecase when a user wants to start playing, toggle play/pause or select next song across all the open tabs.