### PR TITLE
Add art selector for Spotify

### DIFF
--- a/code/js/controllers/SpotifyController.js
+++ b/code/js/controllers/SpotifyController.js
@@ -3,7 +3,7 @@
 
   var BaseController = require("BaseController");
 
-  new BaseController({
+  var controller = new BaseController({
     siteName: "Spotify",
     play: ".now-playing-bar button[class*=play]",
     pause: ".now-playing-bar button[class*=pause]",
@@ -14,6 +14,20 @@
     buttonSwitch: true,
     mute: ".now-playing-bar button[class*=volume]",
     song: ".now-playing-bar .track-info__name",
-    artist: ".now-playing-bar .track-info__artists"
+    artist: ".now-playing-bar .track-info__artists",
+    art: "div.now-playing-bar__left div.cover-art-image.cover-art-image-loaded"
   });
+
+  // Spotify art uses an inline CSS background-image style, this override parses the image from there
+  controller.getArtData = function(selector) {
+    if(!selector) return null;
+
+    var dataEl = this.doc().querySelector(selector);
+
+    if (dataEl !== null)
+    {
+      var backgroundImage = window.getComputedStyle(dataEl)["background-image"];
+      return backgroundImage.match(/url\(["|']?([^"']*)["|']?\)/)[1];
+    }
+  };
 })();


### PR DESCRIPTION
Overrides BaseController's `getArtData` on SpotifyController, since Spotify art is rendered as an inline `style` tag using `background-image: url("https://someurl.jpg")`, instead of something like an `<img>` tag with a `src`.

The regex on line 30 seems pretty advanced for me, I'm now assuming it came from StackOverflow or similar, but can't find the source anymore.  In either case, it seems to work well to take the `background-image: url("https://image.jpg")` CSS string and parse out the image URL.  See it at work here: https://regex101.com/r/DXK8vY/2.  Not sure if there's a much easier way to parse out the `background-image` `url` value that I'm just missing?