### PR TITLE
Add support for pausing playback when a tab is muted.

### DIFF
--- a/code/html/options.html
+++ b/code/html/options.html
@@ -146,6 +146,10 @@
           <input type="checkbox" id="restart-yt" data-bind="checked: $data.youtubeRestart">
           <label for="restart-yt">Play/pause restarts YouTube videos when finished.</label>
         </p>
+        <p class="setting">
+          <input type="checkbox" id="mute-as-pause" data-bind="checked: $data.muteAsPause">
+          <label for="mute-as-pause">Pause/play a video on mute change (requires extension reload).</label>
+        </p>
         <p>
           To change the hotkey bindings go to the chrome extensions page (enter chrome://extensions in the URL bar) and click the "Keyboard shortcuts" link at the bottom of the page. <a href="http://www.streamkeys.com/guide.html" target="_blank">Read the guide</a>          for more detailed information
         </p>

--- a/code/js/modules/Sitelist.js
+++ b/code/js/modules/Sitelist.js
@@ -230,6 +230,9 @@
       if(!obj.hasOwnProperty("hotkey-youtube_restart")) {
         chrome.storage.sync.set({ "hotkey-youtube_restart": false });
       }
+      if(!obj.hasOwnProperty("hotkey-mute_as_pause")) {
+        chrome.storage.sync.set({ "hotkey-mute_as_pause": false });
+      }
     });
   };
 

--- a/code/js/options.js
+++ b/code/js/options.js
@@ -45,6 +45,11 @@ var OptionsViewModel = function OptionsViewModel() {
       chrome.storage.sync.set({ "hotkey-single_player_mode": value });
     });
 
+    self.muteAsPause = ko.observable(obj["hotkey-mute_as_pause"]);
+    self.muteAsPause.subscribe(function(value) {
+      chrome.storage.sync.set({ "hotkey-mute_as_pause": value });
+    });
+
     self.settingsInitialized(true);
   });
 


### PR DESCRIPTION
This can be handy if the tab mute button is enabled with from
chrome://flags. It allows the user to click the mute button to then
pause the playback in addition to muting it.

Unmuting it sends playPause again and should resume the playback.