### PR TITLE
Update StreamsquidController's getArtData function

### DIFF
--- a/code/js/controllers/StreamSquidController.js
+++ b/code/js/controllers/StreamSquidController.js
@@ -39,9 +39,9 @@
     if (selectedItem && selectedItem.attributes) {
       var youtubeIdAttribute = selectedItem.attributes["data-ytid"];
       var imageUrlAttribute = selectedItem.attributes["data-image-url"];
-      // data-image-url is sometimes set, but equal to the string "undefined"
-      if (imageUrlAttribute && imageUrlAttribute.value && imageUrlAttribute.value !== "undefined") {
-        return imageUrlAttribute.value;
+      if (imageUrlAttribute && imageUrlAttribute.value) {
+        // imageUrlAttribute is sometimes a relative URL which we need to convert to an absolute URL to properly get art data
+        return new URL(imageUrlAttribute.value, this.doc().location.protocol + "//" + this.doc().location.host).href;
       }
       else if (youtubeIdAttribute && youtubeIdAttribute.value) {
         return "https://img.youtube.com/vi/" + youtubeIdAttribute.value + "/default.jpg";


### PR DESCRIPTION
I noticed Streamsquid had a UI update, part of which added a generic "No Cover" image to some tracks.  However, this "No Cover" image was referred to with a relative URL, which doesn't do Streamkeys any good when it tries to retrieve art data.

This PR uses [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) to ensure that even if `imageUrlAttribute` is a relative URL, the value we return from `getArtData` here will be an absolute URL.