### PR TITLE
Update YoutubeController song selector, add album, override getArtData

### DIFF
--- a/code/js/controllers/YoutubeController.js
+++ b/code/js/controllers/YoutubeController.js
@@ -3,7 +3,7 @@
 
   var BaseController = require("BaseController");
 
-  new BaseController({
+  var controller = new BaseController({
     siteName: "YouTube",
     playPause: ".ytp-play-button",
     playNext: ".ytp-next-button",
@@ -13,8 +13,19 @@
     dislike: "#menu > ytd-menu-renderer > #top-level-buttons > ytd-toggle-button-renderer:nth-child(2)",
 
     playState: ".ytp-play-button[aria-label='Pause']",
-    song: ".title",
-
+    song: ".title.ytd-video-primary-info-renderer",
+    album: "#playlist .title",
     hidePlayer: true
   });
+
+  controller.getArtData = function() {
+    var params = (new URL(controller.doc().location)).searchParams;
+
+    var vid = params.get("v");
+    if (vid !== null) {
+      return "https://img.youtube.com/vi/" + vid + "/default.jpg";
+    }
+    return null;
+  };
+
 })();


### PR DESCRIPTION
For updating the song selector, previously the `.title` selector would match both the video title and the playlist title if the user in on a playlist view.  I'm not *entirely* sure if that was deliberate...? To me it makes more sense to use the video title for song.

In light of that, also adds an album selector that will pull the name of the playlist when in playlist view.