### PR TITLE
Fixes selector for BrainFM

### DIFF
--- a/code/js/controllers/BrainFMController.js
+++ b/code/js/controllers/BrainFMController.js
@@ -5,8 +5,6 @@
 
   new BaseController({
     siteName: "BrainFM",
-    play: "#play_button.tc_play",
-    pause: "#play_button.tc_pause",
-    buttonSwitch: true
+    playPause: ".modules-music-player-css-PlayControl__wrapper___2ROhW"
   });
 })();

--- a/code/js/controllers/BrainFMController.js
+++ b/code/js/controllers/BrainFMController.js
@@ -5,6 +5,7 @@
 
   new BaseController({
     siteName: "BrainFM",
-    playPause: ".modules-music-player-css-PlayControl__wrapper___2ROhW"
+    playPause: ".modules-music-player-css-PlayControl__wrapper___2ROhW",
+    buttonSwitch: true
   });
 })();


### PR DESCRIPTION
The selector for the play/pause button has changed on Brain.FM. This updates it to match the new selector. They also don't apply a different class for the different states so I compressed it down to using the `playPause` option.