### PR TITLE
Spotify - `like` now uses the add 'Save to Your Music' button instead…

### DIFF
--- a/code/js/controllers/SpotifyController.js
+++ b/code/js/controllers/SpotifyController.js
@@ -9,7 +9,7 @@
     pause: ".now-playing-bar button[class*=pause]",
     playNext: ".now-playing-bar button[class*=skip-forward]",
     playPrev: ".now-playing-bar button[class*=skip-back]",
-    like: ".now-playing-bar button[class*=thumbs-up]",
+    like: ".now-playing button",
     dislike: ".now-playing-bar button[class*=thumbs-down]",
     buttonSwitch: true,
     mute: ".now-playing-bar button[class*=volume]",


### PR DESCRIPTION
The like hotkey only works when in radio mode which triggers the click of the thumbs up button. But it doesn't do anything when playing in normal mode. I replaced the like button with the 'Save to Your Music' button which works in both modes.