### PR TITLE
Add new selectors for iHeartRadio

### DIFF
--- a/code/js/controllers/IheartController.js
+++ b/code/js/controllers/IheartController.js
@@ -5,15 +5,15 @@
 
   new BaseController({
     siteName: "iHeartRadio",
-    play: ".player-controls .icon-play",
-    pause: ".player-controls .icon-pause",
-    playNext: ".player-controls .icon-skip",
+    play: ".player-controls .icon-play,button[data-test='play-button'] > [aria-labelledby='Play']",
+    pause: ".player-controls .icon-pause,button[data-test='play-button'] > [aria-labelledby='Pause']",
+    playNext: ".player-controls .icon-skip,button[data-test='skip-button']",
     mute: ".player-controls .icon-volume",
     like: ".player-controls .icon-thumb-up-unfilled",
     dislike: ".player-controls .icon-thumb-down-unfilled",
 
-    playState: ".player-controls .icon-pause",
-    song: "a.player-song",
-    artist: "a.player-artist"
+    playState: ".player-controls .icon-pause,button[data-test='play-button'] > [aria-labelledby='Pause']",
+    song: "a.player-song,[data-test='mini-player-track-text'],[data-test='fullscreen-player-track-text']",
+    artist: "a.player-artist,[data-test='mini-player-description-text'],[data-test='fullscreen-player-description-text']"
   });
 })();


### PR DESCRIPTION
Noticed the selectors for iHeartRadio were no longer working, so I went through and added to them to match what the player looked like when I used it.

I did leave in the old selectors, in the event that there's a setting or some way to view a player page with the old selectors. The new ones should work with both the mini-player and the fullscreen-player.