### PR TITLE
Add current time and total time selectors, implement for several sites

### DIFF
--- a/code/js/background.js
+++ b/code/js/background.js
@@ -190,15 +190,28 @@
   });
 
   var sendChangeNotification = function(request, sender) {
+    if (!request.stateData.song) {
+      return;
+    }
+
+    var notificationItems = [
+        { title: request.stateData.song.trim(), message: "" },
+      ];
+
+    if (request.stateData.artist || request.stateData.album) {
+      notificationItems.push({ title: (request.stateData.artist || "").trim(), message: (request.stateData.album || "").trim() });
+    }
+
+    if (request.stateData.currentTime || request.stateData.totalTime) {
+      notificationItems.push({ title: (request.stateData.currentTime || "").trim(), message: (request.stateData.totalTime || "").trim() });
+    }
+
     chrome.notifications.create(sender.id + request.stateData.siteName, {
         type: "list",
         title: request.stateData.siteName,
-        message: request.stateData.song || "",
+        message: (request.stateData.song || "").trim(),
         iconUrl: request.stateData.art || chrome.extension.getURL("icon128.png"),
-        items: [
-          { title: request.stateData.song, message: "" },
-          { title: request.stateData.artist || "", message: request.stateData.album || "" }
-        ]
+        items: notificationItems
       }, function(notificationId) {
         if(notificationTimeouts[notificationId])
         {

--- a/code/js/controllers/BandcampController.js
+++ b/code/js/controllers/BandcampController.js
@@ -13,6 +13,9 @@
     song: "a.title_link > span.title",
     artist: "[itemprop=byArtist]",
 
-    hidePlayer: true
+    hidePlayer: true,
+
+    currentTime: ".time_elapsed",
+    totalTime: ".time_total"
   });
 })();

--- a/code/js/controllers/GoogleMusicController.js
+++ b/code/js/controllers/GoogleMusicController.js
@@ -15,6 +15,8 @@
     song: "#currently-playing-title",
     artist: "#player-artist",
     album: ".player-album",
-    art: "#playerBarArt"
+    art: "#playerBarArt",
+    currentTime: "#time_container_current",
+    totalTime: "#time_container_duration"
   });
 })();

--- a/code/js/controllers/SpotifyController.js
+++ b/code/js/controllers/SpotifyController.js
@@ -15,7 +15,11 @@
     mute: ".now-playing-bar button[class*=volume]",
     song: ".now-playing-bar .track-info__name",
     artist: ".now-playing-bar .track-info__artists",
-    art: "div.now-playing-bar__left div.cover-art-image.cover-art-image-loaded"
+    art: "div.now-playing-bar__left div.cover-art-image.cover-art-image-loaded",
+
+    // Messy nth-child selectors, but there is no other class/id/attribute information to distinguish the two times
+    currentTime: ".now-playing-bar .playback-bar__progress-time:nth-child(1)",
+    totalTime: ".now-playing-bar .playback-bar__progress-time:nth-child(3)"
   });
 
   // Spotify art uses an inline CSS background-image style, this override parses the image from there

--- a/code/js/controllers/StreamSquidController.js
+++ b/code/js/controllers/StreamSquidController.js
@@ -16,6 +16,10 @@
     // Because the attributes contain untruncated song and artist names (unlike the DOM Element text)
     song: "data-track-name",
     artist: "data-artist-name",
+
+    // Yes, there is a typo in this id in the DOM
+    currentTime: "#player-time-elpased",
+    totalTime: "#player-duration"
   });
 
   controller.getSelectedQueueItem = function() {
@@ -30,7 +34,7 @@
       return selectedItem.attributes[dataAttribute].value;
     }
 
-    return null;
+    return BaseController.prototype.getSongData.call(this, dataAttribute);
   };
 
   controller.getArtData = function() {

--- a/code/js/controllers/YoutubeController.js
+++ b/code/js/controllers/YoutubeController.js
@@ -15,7 +15,10 @@
     playState: ".ytp-play-button[aria-label='Pause']",
     song: ".title.ytd-video-primary-info-renderer",
     album: "#playlist .title",
-    hidePlayer: true
+    hidePlayer: true,
+
+    currentTime: ".ytp-time-current",
+    totalTime: ".ytp-time-duration"
   });
 
   controller.getArtData = function() {

--- a/code/js/modules/BaseController.js
+++ b/code/js/modules/BaseController.js
@@ -25,7 +25,9 @@
       song: (options.song || null),
       artist: (options.artist || null),
       album: (options.album || null),
-      art: (options.art || null)
+      art: (options.art || null),
+      currentTime: (options.currentTime || null),
+      totalTime: (options.totalTime || null)
     };
 
     // Previous player state, used to check vs current player state to see if anything changed
@@ -185,6 +187,8 @@
       artist: this.getSongData(this.selectors.artist),
       album: this.getSongData(this.selectors.album),
       art: this.getArtData(this.selectors.art),
+      currentTime: this.getSongData(this.selectors.currentTime),
+      totalTime: this.getSongData(this.selectors.totalTime),
       isPlaying: this.isPlaying(),
       siteName: this.siteName,
       canDislike: !!(this.selectors.dislike && this.doc().querySelector(this.selectors.dislike)),


### PR DESCRIPTION
This PR adds selectors to pull the time in the current song, and the duration of the current song, and adds this information to the notification popup like so:

![image](https://user-images.githubusercontent.com/5004786/46587620-aa6af500-ca54-11e8-9831-5ad164763b2b.png)

This implements part of the features outlined in #455.

Also updated the notification popup to exclude lines if they would be empty. For example, since PlexController pulls only song data, not album/artist or time, it displays like so:

![image](https://user-images.githubusercontent.com/5004786/46587656-1188a980-ca55-11e8-9acb-472d568de602.png)