### PR TITLE
Fix MusicForProgramming broken isPlaying state

### DIFF
--- a/code/js/controllers/MusicForProgrammingController.js
+++ b/code/js/controllers/MusicForProgrammingController.js
@@ -13,6 +13,6 @@
   });
 
   controller.isPlaying = function() {
-    return document.querySelector(this.selectors.playState).innerText === "[PAUSE]";
+    return document.querySelector(this.selectors.play).innerText === "[PAUSE]";
   };
 })();


### PR DESCRIPTION
Hello,

Thanks for the awesome extension. Found an issue on musicforprogramming.com. Looks like the `selectors.playState` was `null`, so I changed it to `selectors.play` as it was targeting the correct element. 

Here is a look at the error if you'd like to see:

<img width="1153" alt="screen shot 2018-10-14 at 1 36 40 pm" src="https://user-images.githubusercontent.com/3587605/46920066-7cd2fe00-cfb6-11e8-9bd4-36f03b060f43.png">

I tested the change with the development build. Play/pause now works, as well as `isPlaying` is returning the proper state. Let me know if I can help with anything else. 

Nick