### PR TITLE
Add "next mix" to 8Tracks' "playNext" handler.

### DIFF
--- a/code/js/controllers/8tracksController.js
+++ b/code/js/controllers/8tracksController.js
@@ -3,11 +3,36 @@
 
   var BaseController = require("BaseController");
 
-  new BaseController({
+  function EightTracksController() {
+    // super constructor
+    BaseController.apply(this, arguments);
+
+    // playNext is an array of selectors.
+    // Find the first selector whose style display != none and use that.
+    // This is because in 8Tracks the next button doesn't work if you're
+    // at the end of your mix, so you have to click the "next_mix_button".
+    var originalPlayNext = this.selectors.playNext;
+    Object.defineProperty(this.selectors, "playNext", {
+      get: function() {
+        for (var i = 0; i < originalPlayNext.length; i++) {
+          var el = this.doc().querySelector(originalPlayNext[i]);
+          if (el && el.style.display !== "none") {
+            return originalPlayNext[i];
+          }
+        }
+        // None are valid, just return the first selector
+        return originalPlayNext[0];
+      }.bind(this)
+    });
+  }
+  EightTracksController.prototype = Object.create(BaseController.prototype);
+  EightTracksController.prototype.constructor = BaseController;
+
+  new EightTracksController({
     siteName: "8tracks",
     play: "#player_play_button",
     pause: "#player_pause_button",
-    playNext: "#player_skip_button",
+    playNext: ["#player_skip_button", "#next_mix_button"],
     mute: ".volume-mute",
     like: ".mix-like.inactive",
     dislike: ".mix-like.active",


### PR DESCRIPTION
In 8Tracks, when you get to the end of the "mix" the `#player_skip_button` is hidden and `#next_mix_button` is shown in its place. This PR fixes 8Tracks to determine which button is enabled (via `display: none`) and uses that selector for `selector.playNext` instead.  

An alternative is #473 which would allow any selector property to be a getter.