### PR TITLE
youtube: Fix detection of playing status

### DIFF
--- a/code/js/controllers/YoutubeController.js
+++ b/code/js/controllers/YoutubeController.js
@@ -12,7 +12,7 @@
     like: "#menu > ytd-menu-renderer > #top-level-buttons > ytd-toggle-button-renderer:nth-child(1)",
     dislike: "#menu > ytd-menu-renderer > #top-level-buttons > ytd-toggle-button-renderer:nth-child(2)",
 
-    playState: ".ytp-play-button[aria-label='Pause']",
+    playState: ".ytp-play-button[aria-label^='Pause']",
     song: ".title.ytd-video-primary-info-renderer",
     album: "#playlist .title",
     hidePlayer: true,


### PR DESCRIPTION
The selector for YouTube playState (play button) used to be
".ytp-play-button[aria-label='Pause']" but I recently found that it was
changed to ".ytp-play-button[aria-label='Pause (k)']" in the source of
the YouTube page, breaking the detection of the YouTube playing state in
StreamKeys. Fix that by checking if 'aria-label' begins with 'Pause'
instead of using an exact match.