### PR TITLE
Fix soma.fm controller to reference new elements.

### DIFF
--- a/code/js/controllers/SomaFMController.js
+++ b/code/js/controllers/SomaFMController.js
@@ -6,9 +6,9 @@
   new BaseController({
     siteName: "SomaFM",
     buttonSwitch: true,
-    play: "#playBtn",
-    pause: "#stopBtn",
+    play: ".btn[ng-click^=\"play\"]",
+    pause: ".btn[ng-click^=\"stop\"]",
 
-    playState: "#stopBtn"
+    playState: ".btn[ng-click^=\"stop\"]"
   });
 })();

--- a/code/js/modules/Sitelist.js
+++ b/code/js/modules/Sitelist.js
@@ -145,7 +145,7 @@
       "shortorange": { name: "ShortOrange", url: "http://www.shortorange.com" },
       "siriusxm": { name: "SiriusXM", url: "https://player.siriusxm.com" },
       "slacker": { name: "Slacker", url: "http://www.slacker.com" },
-      "somafm": { name: "SomaFM", url: "http://somafm.com" },
+      "somafm": { name: "SomaFM", url: "http://somafm.com", controller: "SomaFMController.js" },
       "songstr": { name: "Songstr", url: "http://www.songstr.com" },
       "songza": { name: "Songza", url: "http://www.songza.com" },
       "music.sonyentertainmentnetwork": { name: "Sony Music Unlimited", url: "https://music.sonyentertainmentnetwork.com", controller: "SonyMusicUnlimitedController.js" },


### PR DESCRIPTION
These aren't highly desirable selectors, but the newest soma.fm player doesn't appear to apply unique classnames or IDs to these, so an angular attribute selector was used instead.