### PR TITLE
Synology Audio Station support

### DIFF
--- a/code/js/controllers/SynologyAudioStationController.js
+++ b/code/js/controllers/SynologyAudioStationController.js
@@ -1,0 +1,18 @@
+;(function() {
+  "use strict";
+
+  var BaseController = require("BaseController");
+
+  new BaseController({
+    siteName: "Synology Audio Station",
+    playPause: ".player-play button[class*=btn]",
+    playNext: ".player-next button[class*=btn]",
+    playPrev: ".player-prev button[class*=btn]",
+    mute: ".player-volume button[class*=btn]",
+    song: ".info-title > span",
+    artist: ".info-album-artist > span",
+    art: ".player-info-thumb",
+    currentTime: ".info-position",
+    totalTime: ".info-duration"
+  });
+})();

--- a/code/js/modules/Sitelist.js
+++ b/code/js/modules/Sitelist.js
@@ -162,6 +162,7 @@
       "streamelements": { name: "StreamElements", url: "https://streamelements.com/dashboard/songrequest/general" },
       "streamsquid": { name: "StreamSquid", url: "http://streamsquid.com/" },
       "subsonic": { name: "Subsonic", url: "http://www.subsonic.org" },
+      "synology": { name: "Synology Audio Station", url: "https://www.synology.me", controller: "SynologyAudioStationController.js" },
       "tidal": { name: "Tidal", url: "https://www.tidal.com", alias: ["tidalhifi"] },
       "tunein": { name: "TuneIn", url: "http://www.tunein.com" },
       "twitch": { name: "Twitch.tv", url: "http://www.twitch.tv" },


### PR DESCRIPTION
[Synology Audio Station](https://www.synology.com/en-us/dsm/feature/audio_station) is a package available on any Synology NAS, so the alias feature will be very useful for this controller.

Someone already asked for this previously (#292), but I don't think it ever was implemented.

Thank you for the great work on Steamkeys.