### PR TITLE
Update Spotify controller

### DIFF
--- a/code/js/controllers/SpotifyController.js
+++ b/code/js/controllers/SpotifyController.js
@@ -9,13 +9,13 @@
     pause: ".now-playing-bar button[class*=pause]",
     playNext: ".now-playing-bar button[class*=skip-forward]",
     playPrev: ".now-playing-bar button[class*=skip-back]",
-    like: ".now-playing button",
-    dislike: ".now-playing-bar button[class*=thumbs-down]",
+    like: ".now-playing-bar button[class*=heart]",
+    dislike: ".now-playing-bar button[class*=block]",
     buttonSwitch: true,
     mute: ".now-playing-bar button[class*=volume]",
     song: ".now-playing-bar .track-info__name",
     artist: ".now-playing-bar .track-info__artists",
-    art: "div.now-playing-bar__left div.cover-art-image.cover-art-image-loaded",
+    art: ".now-playing-bar .cover-art-image-loaded",
 
     // Messy nth-child selectors, but there is no other class/id/attribute information to distinguish the two times
     currentTime: ".now-playing-bar .playback-bar__progress-time:nth-child(1)",
@@ -24,12 +24,11 @@
 
   // Spotify art uses an inline CSS background-image style, this override parses the image from there
   controller.getArtData = function(selector) {
-    if(!selector) return null;
+    if (!selector) return null;
 
     var dataEl = this.doc().querySelector(selector);
 
-    if (dataEl !== null)
-    {
+    if (dataEl !== null) {
       var backgroundImage = window.getComputedStyle(dataEl)["background-image"];
       return backgroundImage.match(/url\(["|']?([^"']*)["|']?\)/)[1];
     }


### PR DESCRIPTION
The like selector was working but wasn't actually specific enough. There's no reason it wouldn't have also matched the dislike button other than jquery only showing one for some reason.

The dislike selector wasn't working at all, so this makes it work.

The art selector was a bit messy so this just cleans it up a bit.

The formatting changes towards the bottom were done by my editor's formatter (vscode > prettier.io). They are not required, but they are not wrong.