### PR TITLE
Fix Jango controller to reference new elements

### DIFF
--- a/code/js/controllers/JangoController.js
+++ b/code/js/controllers/JangoController.js
@@ -5,13 +5,13 @@
 
   new BaseController({
     siteName: "Jango",
-    playPause: "#btn-playpause",
-    playNext: "#btn-ff",
-    like: "#btn-fav",
-    dislike: "#player_ban",
+    playPause: "#player_play",
+    playNext: "#player_skip",
+    like: "#player_thumbs_up",
+    dislike: "#player_thumbs_down",
 
-    playState: "#btn-playpause.pause",
-    song: "#current-song",
-    artist: "#player_current_artist > a"
+    playState: "#player_play.player_pause",
+    song: "#song_info > span",
+    artist: "#album_info > span > a"
   });
 })();


### PR DESCRIPTION
The Jango website interface has been heavily updated a few months ago, and since this implied name changes of the selectors as well, streamkeys has, since then, become broken. Unfortunately I realised just now that the project is open source, otherwise I would have fixed it much earlier! Please merge and release the fixed version so that the Jango users can enjoy the power of streamkeys again! :)