### PR TITLE
New feature: automatic confirmation of like/dislike

### DIFF
--- a/code/js/controllers/JangoController.js
+++ b/code/js/controllers/JangoController.js
@@ -5,13 +5,13 @@
 
   new BaseController({
     siteName: "Jango",
-    playPause: "#btn-playpause",
-    playNext: "#btn-ff",
-    like: "#btn-fav",
-    dislike: "#player_ban",
+    playPause: "#player_play",
+    playNext: "#player_skip",
+    like: "#player_thumbs_up",
+    dislike: "#player_thumbs_down",
 
-    playState: "#btn-playpause.pause",
-    song: "#current-song",
-    artist: "#player_current_artist > a"
+    playState: "#player_play.player_pause",
+    song: "#song_info > span",
+    artist: "#album_info > span > a"
   });
 })();

--- a/code/js/controllers/JangoController.js
+++ b/code/js/controllers/JangoController.js
@@ -8,7 +8,9 @@
     playPause: "#player_play",
     playNext: "#player_skip",
     like: "#player_thumbs_up",
+    confirmLike: "#thumbs_updown_form_submit > input",
     dislike: "#player_thumbs_down",
+    confirmDislike: "#thumbs_updown_form_submit > input",
 
     playState: "#player_play.player_pause",
     song: "#song_info > span",

--- a/code/js/modules/BaseController.js
+++ b/code/js/modules/BaseController.js
@@ -15,7 +15,9 @@
       playPrev: (options.playPrev || null),
       mute: (options.mute || null),
       like: (options.like || null),
+      confirmLike: (options.confirmLike || null),
       dislike: (options.dislike || null),
+      confirmDislike: (options.confirmDislike || null),
       iframe: (options.iframe || null),
 
       //** States **//
@@ -145,10 +147,26 @@
 
   BaseController.prototype.like = function() {
     this.click({action: "like", selectorButton: this.selectors.like, selectorFrame: this.selectors.iframe});
+    if(this.selectors.confirmLike !== null) {
+      var controller = this;
+      var observer = new MutationObserver(function() {
+        controller.click({action: "confirmLike", selectorButton: controller.selectors.confirmLike, selectorFrame: controller.selectors.iframe});
+        this.disconnect();
+      });
+      observer.observe(document.documentElement, {childList: true, subtree: true});
+    }
   };
 
   BaseController.prototype.dislike = function() {
     this.click({action: "dislike", selectorButton: this.selectors.dislike, selectorFrame: this.selectors.iframe});
+    if(this.selectors.confirmDislike !== null) {
+      var controller = this;
+      var observer = new MutationObserver(function() {
+        controller.click({action: "confirmDislike", selectorButton: controller.selectors.confirmDislike, selectorFrame: controller.selectors.iframe});
+        this.disconnect();
+      });
+      observer.observe(document.documentElement, {childList: true, subtree: true});
+    }
   };
 
   /**

--- a/code/js/modules/BaseController.js
+++ b/code/js/modules/BaseController.js
@@ -150,8 +150,8 @@
     if(this.selectors.confirmLike !== null) {
       var controller = this;
       var observer = new MutationObserver(function() {
-        controller.click({action: "confirmLike", selectorButton: controller.selectors.confirmLike, selectorFrame: controller.selectors.iframe});
         this.disconnect();
+        controller.click({action: "confirmLike", selectorButton: controller.selectors.confirmLike, selectorFrame: controller.selectors.iframe});
       });
       observer.observe(document.documentElement, {childList: true, subtree: true});
     }
@@ -162,8 +162,8 @@
     if(this.selectors.confirmDislike !== null) {
       var controller = this;
       var observer = new MutationObserver(function() {
-        controller.click({action: "confirmDislike", selectorButton: controller.selectors.confirmDislike, selectorFrame: controller.selectors.iframe});
         this.disconnect();
+        controller.click({action: "confirmDislike", selectorButton: controller.selectors.confirmDislike, selectorFrame: controller.selectors.iframe});
       });
       observer.observe(document.documentElement, {childList: true, subtree: true});
     }


### PR DESCRIPTION
Hey Alex, sorry, it's me again. :) This time I have added a new feature that might come in handy.

Since some websites may ask for a confirmation when one clicks on the like/dislike selectors (to the extent of my limited knowledge I only know Jango doing that, but there may be others), I thought it would have been nice if this confirmation could be done automatically without any need of user interaction. So I slightly changed the BaseController to accommodate this in an unobtrusive way.

Since in Jango's case the confirmation is asked through a small modal, and generally speaking, a change in a DOM element is to be expected (because this confirmation has to be prompted to the user somehow), I decided to monitor DOM modifications with a MutationObserver, which is immediately disconnected when its callback is executed, and then fires the click on the confirmLike/confirmDislike selector.

Of course this only happens if the confirmLike/confirmDislike selector is specified in the child controller, otherwise the behavior is just the same as it was before.

With the second commit I also included the working example for the Jango controller.