### PR TITLE
Updated CSS Selector for Play/Pause after Twitch site redesign.

### DIFF
--- a/code/js/controllers/TwitchController.js
+++ b/code/js/controllers/TwitchController.js
@@ -5,7 +5,7 @@
 
   var controller = new BaseController({
     siteName: "Twitch.tv",
-    playPause: ".qa-pause-play-button",
+    playPause: ".player-controls__left-control-group > .tw-inline-flex > .tw-align-items-center",
     song: ".title .real"
   });
 


### PR DESCRIPTION
About a month ago Twitch pushed out their redesign which disrupted the play/pause button css selector. This is reported in #534 