### PR TITLE
Use data-qa-id instead for locale support

### DIFF
--- a/code/js/controllers/PlexController.js
+++ b/code/js/controllers/PlexController.js
@@ -9,7 +9,7 @@
     pause: "div[class^=ControlsContainer] button[data-qa-id=pauseButton]",
     playNext: "div[class^=ControlsContainer] button[data-qa-id=nextButton]",
     playPrev: "div[class^=ControlsContainer] button[data-qa-id=previousButton]",
-    mute: "div[class^=ControlsContainer] button[data-qa-id='volumeButton']",
+    mute: "div[class^=ControlsContainer] button[data-qa-id=volumeButton]",
 
     song: "title",
     buttonSwitch: true

--- a/code/js/controllers/PlexController.js
+++ b/code/js/controllers/PlexController.js
@@ -5,11 +5,11 @@
 
   var controller = new MouseEventController({
     siteName: "Plex.tv",
-    play: "div[class^=ControlsContainer] button[aria-label=Play]",
-    pause: "div[class^=ControlsContainer] button[aria-label=Pause]",
-    playNext: "div[class^=ControlsContainer] button[aria-label=Next]",
-    playPrev: "div[class^=ControlsContainer] button[aria-label=Previous]",
-    mute: "div[class^=ControlsContainer] button[aria-label$='ute Volume']",
+    play: "div[class^=ControlsContainer] button[data-qa-id=resumeButton]",
+    pause: "div[class^=ControlsContainer] button[data-qa-id=pauseButton]",
+    playNext: "div[class^=ControlsContainer] button[data-qa-id=nextButton]",
+    playPrev: "div[class^=ControlsContainer] button[data-qa-id=previousButton]",
+    mute: "div[class^=ControlsContainer] button[data-qa-id='volumeButton']",
 
     song: "title",
     buttonSwitch: true


### PR DESCRIPTION
The current `aria-label` is locale dependent, which causes some buttons to be unavailable.
the `data-qa-id` is locale independent and unique within the ControlsContainer. Which makes it a better candidate for picking the correct button