### PR TITLE
MPRIS support for Brave browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,28 +120,28 @@ $ npm test
 
 ## Linux MPRIS support
 
-On Linux you can enable basic MPRIS support in options. Currently this requires
+On Linux you can enable basic [MPRIS][1] support in options. Currently, this requires
 `single player mode` to be enabled. It requires an extra host script to be
-installed.
+installed. The host script currently supports Chromium, Google Chrome and Brave.
 
 #### Install host script
 
-To install the host script, locate the extension ID from the Chrome extensions page
-and run the following commands:
+To install the host script, run the following commands:
 
 ```bash
-$ extension_id="....."
+$ extension_id="ekpipjofdicppbepocohdlgenahaneen"
 $ installer=$(find $HOME/.config -name "mpris_host_setup.py" | grep ${extension_id})
 $ python3 ${installer} install ${extension_id}
 ```
 
+A restart of the browser is necessary to load the changes.
+
 #### Uninstall host script
 
-To uninstall the host script, locate the extension ID from the Chrome extensions page
-and run the following commands:
+To uninstall the host script, run the following commands:
 
 ```bash
-$ extension_id="....."
+$ extension_id="ekpipjofdicppbepocohdlgenahaneen"
 $ installer=$(find $HOME/.config -name "mpris_host_setup.py" | grep ${extension_id})
 $ python3 ${installer} uninstall
 ```
@@ -151,3 +151,4 @@ $ python3 ${installer} uninstall
 Copyright (c) 2018 Alex Gabriel under the MIT license.
 
 [0]: https://github.com/berrberr/streamkeys/blob/master/code/js/modules/BaseController.js
+[1]: https://specifications.freedesktop.org/mpris-spec/latest/

--- a/code/native/mpris_host_setup.py
+++ b/code/native/mpris_host_setup.py
@@ -40,7 +40,8 @@ def initialize_parser():
 
 
 def get_xdg_config_paths():
-    return [os.path.join(XDG_CONFIG_HOME, "chromium"),
+    return [os.path.join(XDG_CONFIG_HOME, "BraveSoftware/Brave-Browser"),
+            os.path.join(XDG_CONFIG_HOME, "chromium"),
             os.path.join(XDG_CONFIG_HOME, "google-chrome")]
 
 


### PR DESCRIPTION
* The script to installation of the the host script to add MPRIS support works with Chromium and Google Chrome. It did not support the Brave browser, which is based on Chromium as well. I've added support for it to the script.

* I've added more details to the instructions to install the host script, including wich browser are currently supported and added the extension id to it, as it should not change in the future.