### PR TITLE
TwitchController errors

### DIFF
--- a/code/js/controllers/TwitchController.js
+++ b/code/js/controllers/TwitchController.js
@@ -10,7 +10,8 @@
   });
 
   controller.isPlaying = function() {
-    return this.doc().querySelector("[data-a-target='player-play-pause-button']").getAttribute("data-a-player-state") === "playing";
+    var button = this.doc().querySelector("[data-a-target='player-play-pause-button']");
+    return button && button.getAttribute("data-a-player-state") === "playing";
   };
 
 })();


### PR DESCRIPTION
The play/pause button is not always available (there are pages without player), causing console errors in a loop, as querySelector returns undefined.