### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ To install the host script, run the following commands:
 ```bash
 $ extension_id="ekpipjofdicppbepocohdlgenahaneen"
 $ installer=$(find $HOME/.config -name "mpris_host_setup.py" | grep ${extension_id})
-$ python3 ${installer} install ${extension_id}
+$ python3 "${installer}" install ${extension_id}
 ```
 
 A restart of the browser is necessary to load the changes.
@@ -143,7 +143,7 @@ To uninstall the host script, run the following commands:
 ```bash
 $ extension_id="ekpipjofdicppbepocohdlgenahaneen"
 $ installer=$(find $HOME/.config -name "mpris_host_setup.py" | grep ${extension_id})
-$ python3 ${installer} uninstall
+$ python3 "${installer}" uninstall
 ```
 
 ## License (MIT)


### PR DESCRIPTION
Added quotation marks so that the found file will be correctly referred to in the case that it includes whitespace in its name.

Example: ```$HOME/.config/google-chrome/Profile 1/Extensions/ekpipjofdicppbepocohdlgenahaneen/1.8.1_0/native/mpris_host_setup.py``` would be cut into two parts, ```$HOME/.config/google-chrome/Profile``` being the file and ```1/Extensions/ekpipjofdicppbepocohdlgenahaneen/1.8.1_0/native/mpris_host_setup.py``` being an argument. After the addition of the quotation marks, the whole path will be used as the file.