### PR TITLE
Update node.js.yml

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.1
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v2.1.0
       with:


### PR DESCRIPTION
Use the full version number of the github action so that dependabot will update to minor versions (and not just wait for `v2` to become `v3`)