### PR TITLE
Fixing Pocketcasts play button

### DIFF
--- a/code/js/controllers/PocketcastsController.js
+++ b/code/js/controllers/PocketcastsController.js
@@ -4,12 +4,12 @@
 
   new BaseController({
     siteName: "Pocket Casts",
-    playPause: ".play_pause_button",
+    playPause: "button.skip_back_button + button",
     playNext: ".skip-forward-button",
     playPrev: ".skip-back-button",
     mute: ".player-controls-mute-button",
 
-    playState: ".play_pause_button.pause_button",
+    playState: "button.skip_back_button + button[aria-pressed=true]",
     song: ".player_episode",
     artist: ".player_podcast_title"
   });


### PR DESCRIPTION
Pocketcasts broke their player again. They appear to have removed any distinct css classes from the actual play button so I had to get a little creative with css selectors. Tested and verified that it works with the current web player.