### PR TITLE
Update Spotify Controller

### DIFF
--- a/code/js/controllers/SpotifyController.js
+++ b/code/js/controllers/SpotifyController.js
@@ -4,32 +4,20 @@
 
   var controller = new BaseController({
     siteName: "Spotify",
-    play: ".now-playing-bar button[class*=play]",
-    pause: ".now-playing-bar button[class*=pause]",
-    playNext: ".now-playing-bar button[class*=skip-forward]",
-    playPrev: ".now-playing-bar button[class*=skip-back]",
-    like: ".now-playing-bar button[class*=heart]",
+    play: ".now-playing-bar button[title=Play]",
+    pause: ".now-playing-bar button[title=Pause]",
+    playNext: ".now-playing-bar button[title=Previous]",
+    playPrev: ".now-playing-bar button[title=Next]",
+    like: ".now-playing-bar div[class*=heart] button",
     dislike: ".now-playing-bar button[class*=block]",
     buttonSwitch: true,
     mute: ".now-playing-bar button[class*=volume]",
-    song: ".now-playing-bar .track-info__name",
-    artist: ".now-playing-bar .track-info__artists",
-    art: ".now-playing-bar .cover-art-image-loaded",
+    song: ".now-playing div:nth-child(2) div:first-child span",
+    artist: ".now-playing div:nth-child(2) div:last-child span",
+    art: ".cover-art img",
 
     // Messy nth-child selectors, but there is no other class/id/attribute information to distinguish the two times
     currentTime: ".now-playing-bar .playback-bar__progress-time:nth-child(1)",
     totalTime: ".now-playing-bar .playback-bar__progress-time:nth-child(3)"
   });
-
-  // Spotify art uses an inline CSS background-image style, this override parses the image from there
-  controller.getArtData = function(selector) {
-    if (!selector) return null;
-
-    var dataEl = this.doc().querySelector(selector);
-
-    if (dataEl !== null) {
-      var backgroundImage = window.getComputedStyle(dataEl)["background-image"];
-      return backgroundImage.match(/url\(["|']?([^"']*)["|']?\)/)[1];
-    }
-  };
 })();

--- a/code/js/controllers/SpotifyController.js
+++ b/code/js/controllers/SpotifyController.js
@@ -4,10 +4,10 @@
 
   var controller = new BaseController({
     siteName: "Spotify",
-    play: ".now-playing-bar button[title=Play]",
-    pause: ".now-playing-bar button[title=Pause]",
-    playNext: ".now-playing-bar button[title=Previous]",
-    playPrev: ".now-playing-bar button[title=Next]",
+    play: ".player-controls__buttons button:nth-child(3)",
+    pause: ".player-controls__buttons button:nth-child(3)",
+    playNext: ".player-controls__buttons div button",
+    playPrev: ".player-controls__buttons button:nth-child(2)",
     like: ".now-playing-bar div[class*=heart] button",
     dislike: ".now-playing-bar button[class*=block]",
     buttonSwitch: true,


### PR DESCRIPTION
Spotify now uses random class names for (almost) all the control elements. This changes to using the title of the buttons.

Some of these selectors are not great, but with Spotify's switch to using random class names, some nth-child() selectors are needed.

This has not been tested with the extension, but I did make sure all the selectors worked correctly when .click() was used on them.