### PR TITLE
Fix Spotify skip to next song

### DIFF
--- a/code/js/controllers/SpotifyController.js
+++ b/code/js/controllers/SpotifyController.js
@@ -6,7 +6,7 @@
     siteName: "Spotify",
     play: ".player-controls__buttons button:nth-child(3)",
     pause: ".player-controls__buttons button:nth-child(3)",
-    playNext: ".player-controls__buttons div button",
+    playNext: ".player-controls__buttons button:nth-child(4)",
     playPrev: ".player-controls__buttons button:nth-child(2)",
     like: ".now-playing-bar div[class*=heart] button",
     dislike: ".now-playing-bar button[class*=block]",


### PR DESCRIPTION
With the latest fixes in https://github.com/berrberr/streamkeys/pull/698 by @jhollowe the buttons seem to be fixed, with the exception of skipping to the next song. Instead it activates the repeat/repeat one button.
To follow the convention I just selected the 4th child in `.player-controls__buttons`