### PR TITLE
Added site controller for promodj.com.

### DIFF
--- a/code/js/controllers/PromodjController.js
+++ b/code/js/controllers/PromodjController.js
@@ -1,0 +1,16 @@
+"use strict";
+(function() {
+  var BaseController = require("BaseController");
+
+  new BaseController({
+    siteName: "Promo DJ",
+
+    play: "img.playerr_bigplaybutton",
+    pause: "img.playerr_bigpausebutton",
+    buttonSwitch: true,
+
+    playState: "img.playerr_bigpausebutton",
+    song: ".current",
+    artist: "title"
+  });
+})();

--- a/code/js/modules/Sitelist.js
+++ b/code/js/modules/Sitelist.js
@@ -140,6 +140,7 @@
       "poolside": { name: "Poolside FM", url: "https://poolside.fm/", controller: "PoolsideFM.js", alias: ["poolsidefm"] },
       "primephonic": {name: "Primephonic", url: "https://www.primephonic.com/"},
       "primevideo": {name: "Prime Video", url: "https://www.primevideo.com"},
+      "promodj": {name: "Promo DJ", url: "https://www.promodj.com"},
       "qobuz": { name: "Qobuz", url: "https://play.qobuz.com" },
       "music.qq": { name: "QQ Music", url: "https://y.qq.com/portal/player.html", controller: "QQController.js", alias: ["y.qq.com/portal/player.html"] },
       "radioparadise": { name: "RadioParadise", url: "http://www.radioparadise.com" },


### PR DESCRIPTION
DJs on Promo DJ sometimes do not set their mixes up such that author and title can be properly scraped by a simple site controller. Some channels therefore do not display properly in streamkeys. However, the listener can use the media buttons to play/pause on the site, which is an important feature.