### PR TITLE
Update Plex targeting attributes

### DIFF
--- a/code/js/controllers/PlexController.js
+++ b/code/js/controllers/PlexController.js
@@ -4,11 +4,11 @@
 
   var controller = new MouseEventController({
     siteName: "Plex.tv",
-    play: "div[class^=ControlsContainer] button[data-qa-id=resumeButton]",
-    pause: "div[class^=ControlsContainer] button[data-qa-id=pauseButton]",
-    playNext: "div[class^=ControlsContainer] button[data-qa-id=nextButton]",
-    playPrev: "div[class^=ControlsContainer] button[data-qa-id=previousButton]",
-    mute: "div[class^=ControlsContainer] button[data-qa-id=volumeButton]",
+    play: "div[class^=ControlsContainer] button[data-testid=resumeButton]",
+    pause: "div[class^=ControlsContainer] button[data-testid=pauseButton]",
+    playNext: "div[class^=ControlsContainer] button[data-testid=nextButton]",
+    playPrev: "div[class^=ControlsContainer] button[data-testid=previousButton]",
+    mute: "div[class^=ControlsContainer] button[data-testid=volumeButton]",
 
     song: "title",
     buttonSwitch: true


### PR DESCRIPTION
Plex has changed from `data-qa-id` to `data-testid` at some point. Everything else, including the attribute values, appears to be the same.